### PR TITLE
fix(action): sort files after find and before split

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Assert files (1/2)
         shell: bash
         run: |
-          if [[ '${{ steps.test1.outputs.files }}' != ./test/[1-3].spec[[:space:]]./test/[1-3].spec[[:space:]] ]]; then
+          if [[ '${{ steps.test1.outputs.files }}' != './test/1.spec ./test/2.spec ' ]]; then
             echo 'Files do not match'
             exit 1
           fi
@@ -38,7 +38,7 @@ jobs:
       - name: Assert files (2/2)
         shell: bash
         run: |
-          if [[ '${{ steps.test2.outputs.files }}' != test/[1-3].spec[[:space:]] ]]; then
+          if [[ '${{ steps.test2.outputs.files }}' != 'test/3.spec ' ]]; then
             echo 'Files do not match'
             exit 1
           fi

--- a/README.md
+++ b/README.md
@@ -31,16 +31,16 @@ jobs:
 
 ## Usage
 
-See [action.yml](action.yml)
-
-**Basic:**
+Find half of the files matching `*.txt` in alphabetical order:
 
 ```yaml
 - uses: remarkablemark/find-and-split@v1
   with:
     pattern: '*.txt'
-    chunk: 1/3
+    chunk: 1/2
 ```
+
+See [action.yml](action.yml)
 
 ## Inputs
 

--- a/action.yml
+++ b/action.yml
@@ -37,7 +37,7 @@ runs:
         PREFIX=find_and_split_${{ github.run_id }}_
         FILE=$RUNNER_TEMP/$PREFIX
 
-        find ${{ inputs.directory }} -type f -name ${{ inputs.pattern }} > $FILE
+        find ${{ inputs.directory }} -type f -name ${{ inputs.pattern }} | sort > $FILE
 
         FILES_TOTAL=$(wc -l < $FILE)
         LINES=$(( (FILES_TOTAL + 1) / CHUNK_TOTAL ))


### PR DESCRIPTION
## What is the motivation for this pull request?

The `find` command in Bash does not guarantee a specific order of results by default. As a result, `sort` the output of `find` for deterministic results.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation