### PR TITLE
fix(action): show error message when no files are found and change back to previous directory

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
         uses: ./
         with:
           chunk: 0/1
-          directory: invalid
           pattern: '*.invalid'
         continue-on-error: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Find and split (0/1)
+        uses: ./
+        with:
+          chunk: 0/1
+          directory: invalid
+          pattern: '*.invalid'
+        continue-on-error: true
+
       - name: Find and split (1/2)
         uses: ./
         id: test1

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,8 @@ runs:
           echo $EOF
         } >> "$GITHUB_OUTPUT"
 
+        cd -
+
 branding:
   icon: scissors
   color: yellow

--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,14 @@ runs:
 
         find ${{ inputs.directory }} -type f -name ${{ inputs.pattern }} | sort > $FILE
 
-        FILES_TOTAL=$(wc -l < $FILE)
+        FILES_TOTAL=$(wc -l < $FILE | xargs)
         LINES=$(( (FILES_TOTAL + 1) / CHUNK_TOTAL ))
         MAX_DIGITS=3
+
+        if [[ $FILES_TOTAL == 0 ]]; then
+          echo 'No files found. Check your inputs: pattern = "${{ inputs.pattern }}", directory = "${{ inputs.directory }}"'
+          exit 1
+        fi
 
         cd $RUNNER_TEMP
         split -d -a $MAX_DIGITS -l $LINES $FILE $PREFIX

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,9 @@ runs:
         MAX_DIGITS=3
 
         if [[ $FILES_TOTAL == 0 ]]; then
-          echo 'No files found. Check your inputs: pattern = "${{ inputs.pattern }}", directory = "${{ inputs.directory }}"'
+          echo 'No files found. Check your inputs:'
+          echo '- pattern: ${{ inputs.pattern }}'
+          echo '- directory: ${{ inputs.directory }}'
           exit 1
         fi
 


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(action): show error message when no files are found and change back to previous directory

## What is the current behavior?

Error when no files are found due to invalid pattern/directory input(s):

```
split: 0: illegal line count
```

After the action ends, the directory has changed to the temp runner directory

## What is the new behavior?

Error when no files are found:

```
No files found. Check your inputs:
- pattern: *.invalid
- directory: .
```

After the action ends, the directory has changed back to previous working directory

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation